### PR TITLE
🐛 Remove obsolete zipper submodule from ``.gitmodules``

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "libs/siqadconn"]
 	path = libs/siqadconn
 	url = https://github.com/siqad/siqadconn
-[submodule "src/libs/zipper"]
-	path = src/libs/zipper
-	url = https://github.com/sebastiandev/zipper
 [submodule "plugins/mnt-siqad-plugins"]
 	path = plugins/mnt-siqad-plugins
 	url = https://github.com/cda-tum/mnt-siqad-plugins


### PR DESCRIPTION
``zipper`` does not exist anymore. However, it is still listed as a submodule, which leads to issues with the depandabot. This PR removes ``zipper`` from ``.gitmodules``.