### PR TITLE
:green_heart: Added libs path to cause CI run.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,6 +10,7 @@ on:
       - '**/*.cmake'
       - '**/CMakeLists.txt'
       - 'libs/**'
+      - 'plugins/**'
       - '.github/workflows/macos.yml'
   pull_request:
     branches: ["master"]
@@ -19,7 +20,7 @@ on:
       - '**/*.cc'
       - '**/*.cmake'
       - '**/CMakeLists.txt'
-      - 'libs/**'
+      - 'plugins/**'
       - '.github/workflows/macos.yml'
   merge_group:
 


### PR DESCRIPTION
This pull request makes minor updates to the GitHub Actions workflow trigger configuration in `.github/workflows/macos.yml`. The changes adjust which file patterns will trigger the workflow on push and pull request events, specifically shifting attention from the `libs` directory to the `plugins` directory.
